### PR TITLE
Add auto-author assignment for PRs and issues

### DIFF
--- a/.github/workflows/auto-author-sign.yml
+++ b/.github/workflows/auto-author-sign.yml
@@ -1,0 +1,16 @@
+name: Auto Author Assign
+
+on:
+  issues:
+    types: [ opened, reopened ]
+  pull_request_target:
+    types: [ opened, reopened ]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: toshimaru/auto-author-assign@v3.0.1


### PR DESCRIPTION
## Describe your changes
The user making the PR or issue now gets automatically assigned when they open or reopen a ticket! 🥳 

**Source:** https://github.com/marketplace/actions/auto-author-assign